### PR TITLE
Fix #32 - Prevent the definition of source folder to be a file

### DIFF
--- a/lib/Infrastructure/Filesystem/Exception/SourceFolderException.php
+++ b/lib/Infrastructure/Filesystem/Exception/SourceFolderException.php
@@ -20,4 +20,14 @@ final class SourceFolderException extends \Exception implements KataException
     {
         return new self("The source folder '{$folder}' do not exists.");
     }
+
+    /**
+     * @param string $path
+     *
+     * @return SourceFolderException
+     */
+    public static function sourceFolderMustBeADirectory($path)
+    {
+        return new self("The source folder must be a directory, '{$path}' given.");
+    }
 }

--- a/lib/Infrastructure/Filesystem/FilesystemEnvironment.php
+++ b/lib/Infrastructure/Filesystem/FilesystemEnvironment.php
@@ -166,4 +166,20 @@ final class FilesystemEnvironment implements Environment
             throw EnvironmentException::environmentNotLoaded();
         }
     }
+
+    /**
+     * @param string $basePath
+     * @param string $srcPath
+     *
+     * @return FilesystemEnvironment
+     */
+    public static function setup($basePath, $srcPath = 'src')
+    {
+        $fullPath = $basePath . DIRECTORY_SEPARATOR . $srcPath;
+        if (! file_exists($fullPath)) {
+            mkdir($fullPath);
+        }
+
+        return new self($basePath, $srcPath);
+    }
 }

--- a/lib/Infrastructure/Filesystem/SourceFolder.php
+++ b/lib/Infrastructure/Filesystem/SourceFolder.php
@@ -27,6 +27,10 @@ final class SourceFolder
             throw SourceFolderException::sourceFolderDoNotExists($folder);
         }
 
+        if (! is_dir($folder)) {
+            throw SourceFolderException::sourceFolderMustBeADirectory($folder);
+        }
+
         $this->folder = $folder;
     }
 

--- a/phpkata.php
+++ b/phpkata.php
@@ -12,6 +12,5 @@ use Star\Kata\Infrastructure\Filesystem\FilesystemEnvironment;
 use Star\Kata\KataApplication;
 use Symfony\Component\Console\Input\ArgvInput;
 
-$environment = new FilesystemEnvironment(__DIR__, 'src');
-$application = new KataApplication($environment);
+$application = new KataApplication(FilesystemEnvironment::setup(__DIR__, 'src'));
 $application->run(new ArgvInput($argv));

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,8 @@
 
     <testsuites>
         <testsuite name="main">
-            <directory>tests/PHPUnit</directory>
+            <directory suffix=".php">tests/PHPUnit</directory>
+            <directory suffix=".phpt">tests/PHPUnit/Regressions</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/PHPUnit/Infrastructure/Filesystem/FilesystemEnvironmentTest.php
+++ b/tests/PHPUnit/Infrastructure/Filesystem/FilesystemEnvironmentTest.php
@@ -10,6 +10,7 @@ namespace Star\Kata\Infrastructure\Filesystem;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
+use Star\Kata\Domain\Environment;
 use Star\Kata\KataMock;
 
 /**
@@ -117,5 +118,12 @@ final class FilesystemEnvironmentTest extends \PHPUnit_Framework_TestCase
     public function test_it_should_throw_exception_when_publishing_on_not_loaded_env()
     {
         $this->environment->publish($this->getMockKataEvent());
+    }
+
+    public function test_it_should_create_source_folder_when_it_do_not_exists()
+    {
+        $this->assertFalse($this->root->hasChild('src'));
+        $this->assertInstanceOf(Environment::class, FilesystemEnvironment::setup($this->root->url()));
+        $this->assertTrue($this->root->hasChild('src'));
     }
 }

--- a/tests/PHPUnit/Infrastructure/Filesystem/SourceFolderTest.php
+++ b/tests/PHPUnit/Infrastructure/Filesystem/SourceFolderTest.php
@@ -59,4 +59,14 @@ final class SourceFolderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->root->hasChild('file'));
         $this->assertSame('content', $this->sourceFolder->readFile('file'), 'Returns content when file found');
     }
+
+    /**
+     * @expectedException        \Star\Kata\Infrastructure\Filesystem\Exception\SourceFolderException
+     * @expectedExceptionMessage The source folder must be a directory, 'vfs://root/file' given.
+     */
+    public function test_it_should_throw_exception_when_source_folder_is_file()
+    {
+        $this->root->addChild(new vfsStreamFile('file'));
+        new SourceFolder($this->root->getChild('file')->url());
+    }
 }

--- a/tests/PHPUnit/Regressions/help-output.phpt
+++ b/tests/PHPUnit/Regressions/help-output.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Assert that the help output always show the right information
+--FILE--
+<?php
+$_SERVER['argv'][1] = '--help';
+require __DIR__ . '/../../../phpkata.php';
+?>
+--EXPECTF--
+#!/usr/bin/env php
+phpkata version 0.1.0
+
+Usage:
+ command [options] [arguments]
+
+Options:
+ --help (-h)           Display this help message
+ --quiet (-q)          Do not output any message
+ --verbose (-v|vv|vvv) Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+ --version (-V)        Display this application version
+ --ansi                Force ANSI output
+ --no-ansi             Disable ANSI output
+ --no-interaction (-n) Do not ask any interactive question
+
+Available commands:
+ continue   End the specified kata.
+ help       Displays help for a command
+ list       Lists commands
+ start      Start the specified kata.
+

--- a/tests/features/bootstrap/KataContext.php
+++ b/tests/features/bootstrap/KataContext.php
@@ -53,12 +53,7 @@ class KataContext extends BehatContext
     {
         $this->output = new BufferedOutput();
         $this->basePath = __DIR__ . DIRECTORY_SEPARATOR . 'testSrc';
-
-        if (false === file_exists($this->basePath)) {
-            mkdir($this->basePath);
-        }
-
-        $this->environment = new FilesystemEnvironment(__DIR__, 'testSrc');
+        $this->environment = FilesystemEnvironment::setup(__DIR__, 'testSrc');
         $this->application = new ApplicationTester($this->environment);
     }
 


### PR DESCRIPTION
* Include a test for the help command.
* Enable the regressions tests (PHPT)
* Add check that the source folder is a dir
* Add automatic generation of source dir when it do not exists.